### PR TITLE
CompTest: Allow compilation on Ubuntu 16.04.5

### DIFF
--- a/dll/serialunix/build.sh
+++ b/dll/serialunix/build.sh
@@ -32,8 +32,9 @@ echo ======================================================================
 echo == Building Project
 echo ======================================================================
 #Enable this line instead of the other to build with logging
-#CFLAGS="-O0 -g -Wall" cmake -DCMAKE_BUILD_TYPE=Debug -DNSLOG_ENABLED=ON .. && make
-CFLAGS="-O0 -g -Wall" cmake -DCMAKE_BUILD_TYPE=Debug -DNSLOG_ENABLED=OFF .. && make
+cmake -E env CFLAGS="-O0 -g -Wall" CXXFLAGS="-std=c++11 -Wall" \
+  cmake -DCMAKE_BUILD_TYPE=Debug -DNSLOG_ENABLED=OFF .. \
+  && make
 if test $? = 0; then
   make test CTEST_OUTPUT_ON_FAILURE=1
   make install DESTDIR=$PROJECTBIN

--- a/dll/serialunix/libnserial/comptest/SerialReadWrite.cpp
+++ b/dll/serialunix/libnserial/comptest/SerialReadWrite.cpp
@@ -38,9 +38,6 @@ int SerialReadWrite::DoTransfer(Buffer *sendBuffer)
 
   m_writebuff = sendBuffer;
 
-  char *rbuff = m_readbuff->GetBuffer();
-  char *wbuff = m_writebuff->GetBuffer();
-
   int error = 0;
 
   bool writefinished;
@@ -50,7 +47,6 @@ int SerialReadWrite::DoTransfer(Buffer *sendBuffer)
   // Read all data from the serial port.
   writefinished = false;
   readfinished = false;
-  char tmpbuff[256];
 
   serial_reset(m_writehandle);
   serial_reset(m_readhandle);


### PR DESCRIPTION
When implementing DOTNET-159 (commit b36cdd2 "Test Cases: Fix compatibility issues with GCC 7.3.0"), the build.sh script would fail on Ubuntu 16.04 as the "unique_ptr" couldn't be found.

Tell the C++ compiler (GNU 5.4.0) to use C++11 (-std=c++11) in build.sh. Note, if you compile it yourself with cmake, you need to make sure you provide the correct compiler options yourself.

Issue: DOTNET-180